### PR TITLE
improving_docs

### DIFF
--- a/adafruit_mlx90614.py
+++ b/adafruit_mlx90614.py
@@ -75,8 +75,8 @@ class MLX90614:
     """Create an instance of the MLX90614 temperature sensor.
 
     :param ~busio.I2C i2c_bus: The I2C bus the MLX90614 is connected to.
-                               frequency=100000 - this sensor does not
-                               respond to a  400000 i2c bus speed
+                               Do not use an I2C bus speed of 400kHz. The sensor only works
+                               at the default bus speed of 100kHz.
     :param int address: I2C device address. Defaults to :const:`0x5A`.
 
     **Quickstart: Importing and using the MLX90614**

--- a/adafruit_mlx90614.py
+++ b/adafruit_mlx90614.py
@@ -34,7 +34,7 @@ Implementation Notes
 **Software and Dependencies:**
 
 * Adafruit CircuitPython firmware for the supported boards:
-  https://github.com/adafruit/circuitpython/releases
+  https://circuitpython.org/downloads
 """
 
 from micropython import const
@@ -72,14 +72,37 @@ _MLX90614_ID4 = const(0x3F)
 
 
 class MLX90614:
-    """Create an instance of the MLX90614 temperature sensor.  You must pass in
-    the following parameters:
-    - i2c: An instance of the I2C bus connected to the sensor.
-    - frequency=100000 - this sensor does not respond to the default 400000 i2c bus speed
+    """Create an instance of the MLX90614 temperature sensor.
 
-    Optionally you can specify:
-    - address: The I2C address of the sensor.
-    If not specified the sensor's default value will be assumed."""
+    :param ~busio.I2C i2c_bus: The I2C bus the MLX90614 is connected to.
+                               frequency=100000 - this sensor does not
+                               respond to a  400000 i2c bus speed
+    :param int address: I2C device address. Defaults to :const:`0x5A`.
+
+    **Quickstart: Importing and using the MLX90614**
+
+        Here is an example of using the :class:`MLX90614` class.
+        First you will need to import the libraries to use the sensor
+
+        .. code-block:: python
+
+            import board
+            import adafruit_mlx90614
+
+        Once this is done you can define your `board.I2C` object and define your sensor object
+
+        .. code-block:: python
+
+            i2c = board.I2C()
+            mlx = adafruit_mlx90614.MLX90614(i2c)
+
+        Now you have access to the :attr:`ambient_temperature` attribute
+
+        .. code-block:: python
+
+            temperature = mlx.ambient_temperature
+
+    """
 
     def __init__(self, i2c_bus, address=_MLX90614_I2CADDR):
         self._device = i2c_device.I2CDevice(i2c_bus, address)
@@ -88,12 +111,12 @@ class MLX90614:
 
     @property
     def ambient_temperature(self):
-        """Ambient Temperature in celsius."""
+        """Ambient Temperature in Celsius."""
         return self._read_temp(_MLX90614_TA)
 
     @property
     def object_temperature(self):
-        """Object Temperature in celsius."""
+        """Object Temperature in Celsius."""
         return self._read_temp(_MLX90614_TOBJ1)
 
     def _read_temp(self, register):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Table of Contents
 .. toctree::
     :caption: Tutorials
 
-    https://github.com/adafruit/Adafruit_Learning_System_Guides/tree/master/DIY_Thermal_Light_Painting
+    Using Melexis MLX90614 Non-Contact Sensors Learning Guide <https://learn.adafruit.com/using-melexis-mlx90614-non-contact-sensors>
 
 .. toctree::
     :caption: Related Products

--- a/examples/mlx90614_simpletest.py
+++ b/examples/mlx90614_simpletest.py
@@ -13,13 +13,11 @@
 #  products from Adafruit!
 
 import board
-import busio as io
 import adafruit_mlx90614
 
 # the mlx90614 must be run at 100k [normal speed]
-# i2c default mode is is 400k [full speed]
-# the mlx90614 will not appear at the default 400k speed
-i2c = io.I2C(board.SCL, board.SDA, frequency=100000)
+# the mlx90614 will not appear at the 400k speed
+i2c = board.I2C()
 mlx = adafruit_mlx90614.MLX90614(i2c)
 
 # temperature results in celsius

--- a/examples/mlx90614_simpletest.py
+++ b/examples/mlx90614_simpletest.py
@@ -15,8 +15,8 @@
 import board
 import adafruit_mlx90614
 
-# the mlx90614 must be run at 100k [normal speed]
-# the mlx90614 will not appear at the 400k speed
+# The MLX90614 only works at the default I2C bus speed of 100kHz.
+# A higher speed, such as 400kHz, will not work.
 i2c = board.I2C()
 mlx = adafruit_mlx90614.MLX90614(i2c)
 


### PR DESCRIPTION
As title States, need to change some of the comments as previously it was mentioned the the default speed for the I2C bus was 400000 Hz, however I verified here:
https://circuitpython.readthedocs.io/en/latest/shared-bindings/busio/index.html#busio.I2C
And it is 100000 Hz